### PR TITLE
chore: conventinal commits use lowercase in examples

### DIFF
--- a/.github/workflows/pr-title-validation.yaml
+++ b/.github/workflows/pr-title-validation.yaml
@@ -28,9 +28,9 @@ jobs:
             chore
           # Configure that a scope must always be provided.
           requireScope: false
-          # Configure additional validation for the subject based on a regex.
-          # This example ensures the subject starts with an uppercase character.
-          subjectPattern: ^[A-Z].+$
+          # # Configure additional validation for the subject based on a regex.
+          # # This example ensures the subject starts with an uppercase character.
+          # subjectPattern: ^[A-Z].+$
           # If `subjectPattern` is configured, you can use this property to override
           # the default error message that is shown when the pattern doesn't match.
           # The variables `subject` and `title` can be used within the message.


### PR DESCRIPTION
Make checks compatible with
https://www.conventionalcommits.org/en/v1.0.0/