### PR TITLE
fix: Remove `v` prefix in Dockerfile and Github Action `_VERSION` variables

### DIFF
--- a/default.template.json5
+++ b/default.template.json5
@@ -75,10 +75,17 @@
       "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
     },
     {
-      "description": "Remove v prefix in regex `_VERSION` updates",
+      "description": "Remove v prefix in Dockerfile and GHA `_VERSION` updates",
       "matchManagers": ["regex"],
       "extractVersion": "^?v?(?<version>\\d+\\.\\d+\\.\\d+)$",
-      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
+      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$",
+      "fileMatch": [
+        // regexManagers:dockerfileVersions
+        "(^|/|\\.)Dockerfile$",
+        "(^|/)Dockerfile[^/]*$",
+        // regexManagers:githubActionsVersions
+        "^.github/(?:workflows|actions)/.+\\.ya?ml$"
+      ],
     },
   ],
   // No files by default. Enable to all possible files                        | https://docs.renovatebot.com/modules/manager/kubernetes/

--- a/default.template.json5
+++ b/default.template.json5
@@ -69,7 +69,7 @@
   },
   "packageRules": [
     {
-      "description": "v prefix workaround for GHA updates",
+      "description": "v prefix workaround for action updates",
       "matchDepTypes": ["action"],
       "extractVersion": "^(?<version>v\\d+\\.\\d+\\.\\d+)$",
       "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"

--- a/default.template.json5
+++ b/default.template.json5
@@ -75,17 +75,10 @@
       "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
     },
     {
-      "description": "Remove v prefix in Dockerfile and GHA `_VERSION` updates",
+      "description": "Remove v prefix in regex `_VERSION` updates",
       "matchManagers": ["regex"],
       "extractVersion": "^?v?(?<version>\\d+\\.\\d+\\.\\d+)$",
-      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$",
-      "fileMatch": [
-        // regexManagers:dockerfileVersions
-        "(^|/|\\.)Dockerfile$",
-        "(^|/)Dockerfile[^/]*$",
-        // regexManagers:githubActionsVersions
-        "^.github/(?:workflows|actions)/.+\\.ya?ml$"
-      ],
+      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
     },
   ],
   // No files by default. Enable to all possible files                        | https://docs.renovatebot.com/modules/manager/kubernetes/

--- a/default.template.json5
+++ b/default.template.json5
@@ -69,10 +69,16 @@
   },
   "packageRules": [
     {
-      "description": "v prefix workaround for action and Dockerfile updates",
-      "matchDepTypes": ["action", "docker"],
+      "description": "v prefix workaround for GHA updates",
+      "matchDepTypes": ["action"],
       "extractVersion": "^(?<version>v\\d+\\.\\d+\\.\\d+)$",
       "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
+    },
+    {
+      "description": "Remove v prefix in regex `_VERSION` updates",
+      "matchManagers": ["regex"],
+      "extractVersion": "^?v?(?<version>\\d+\\.\\d+\\.\\d+)$",
+      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
     },
   ],
   // No files by default. Enable to all possible files                        | https://docs.renovatebot.com/modules/manager/kubernetes/


### PR DESCRIPTION
Put an `x` into the box if that applies:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

[v1.2.0](https://github.com/SpotOnInc/renovate-config/releases/tag/v1.2.0) says that it introduces the removal of `v` prefix in `_VERSION` variables for Dockerfiles, but eventually, it did not work.

This PR fixes it and makes able to avoid the addition of not needed `v` prefix for  `_VERSION` in Github Actions too.

### How was it tested

Test repo with Enable Renovate and 2 files in repo root:

* `renovate.json5` with the same settings as in this PR
* Dockerfile with stuff like:

   ```dockerfile
   # renovate: datasource=github-releases depName=driftctl lookupName=snyk/driftctl
   ARG DRIFTCTL_VERSION=0.38.0
   RUN curl -sSL https://github.com/snyk/driftctl/releases/download/v${DRIFTCTL_VERSION}/driftctl_linux_${ARCH} -o /usr/local/bin/driftctl \
       && chmod +x /usr/local/bin/driftctl
   ```
