### PR TITLE
fix: Removal `v` prefix in `_VERSION` now support `X.Y.Zany.thing` tags

### DIFF
--- a/default.template.json5
+++ b/default.template.json5
@@ -77,8 +77,8 @@
     {
       "description": "Remove v prefix in regex `_VERSION` updates",
       "matchManagers": ["regex"],
-      "extractVersion": "^?v?(?<version>\\d+\\.\\d+\\.\\d+)$",
-      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
+      "extractVersion": "^?v?(?<version>\\d+\\.\\d+\\.\\d+.*)$",
+      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+.*))?$"
     },
   ],
   // No files by default. Enable to all possible files                        | https://docs.renovatebot.com/modules/manager/kubernetes/


### PR DESCRIPTION
Put an `x` into the box if that applies:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

