### PR TITLE
chore: Don't write GH comment on PRs inculuded in release (fix)

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,6 +8,14 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     [
+      "@semantic-release/github",
+      {
+        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
+        "labels": false,
+        "releasedLabels": false
+      }
+    ],
+    [
       "@semantic-release/changelog",
       {
         "changelogFile": "CHANGELOG.md",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,7 @@
     [
       "@semantic-release/github",
       {
-        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
+        "successComment": false,
         "labels": false,
         "releasedLabels": false
       }


### PR DESCRIPTION
This block needed to create Release in Github

Relates SpotOnInc/renovate-config#65