### PR TITLE
feat: Check docker deps longer to bypass Docker Hub rate limits

### DIFF
--- a/default.template.json5
+++ b/default.template.json5
@@ -80,6 +80,12 @@
       "extractVersion": "^?v?(?<version>\\d+\\.\\d+\\.\\d+.*)$",
       "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+.*))?$"
     },
+    {
+      // Extend update period because of Docker Hub API rate limits.
+      // That can be avoided by making self-hosted Renovate and providing token.
+      "matchDatasources": ["docker"],
+      "schedule": ["after 4am on monday and tuesday"],
+    }
   ],
   // No files by default. Enable to all possible files                        | https://docs.renovatebot.com/modules/manager/kubernetes/
   "kubernetes": {


### PR DESCRIPTION
Another solution - use self-hosted Renovate and provide a Token


Put an `x` into the box if that applies:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.
