### PR TITLE
feat: Bypass Docker Hub rate limits, by prioritize docker updates

### DIFF
--- a/default.template.json5
+++ b/default.template.json5
@@ -32,8 +32,6 @@
   "dependencyDashboardTitle": "Renovate Dependency Dashboard",
   "dependencyDashboardLabels": ["auto-update"],
   "dependencyDashboardHeader": "This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more.<br>Main configs and useful links are located in [SpotOnInc/renovate-config](https://github.com/SpotOnInc/renovate-config); Renovate logs for debug [here](https://developer.mend.io/{{platform}}/{{repository}}).",
-  // Limit branch creation to these times of day or week.                     | https://docs.renovatebot.com/configuration-options/#schedule
-  "schedule": ["after 4am on monday"],
   // Wait at least 3 days for possible fixes before creating a branch/PR.     | https://docs.renovatebot.com/configuration-options/#minimumreleaseage
   "minimumReleaseAge": "3 days",
   // Create PRs to roll back versions
@@ -67,6 +65,10 @@
   "pre-commit": {
     "enabled": true
   },
+  // No files by default. Enable to all possible files                        | https://docs.renovatebot.com/modules/manager/kubernetes/
+  "kubernetes": {
+    "fileMatch": ["\\.yaml$"]
+  },
   "packageRules": [
     {
       "description": "v prefix workaround for action updates",
@@ -81,14 +83,20 @@
       "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+.*))?$"
     },
     {
-      // Extend update period because of Docker Hub API rate limits.
-      // That can be avoided by making self-hosted Renovate and providing token.
-      "matchDatasources": ["docker"],
-      "schedule": ["after 4am on monday and tuesday"],
-    }
+      // Extend the update period because of Docker Hub API rate limits.
+      // That can be avoided by making a self-hosted Renovate and providing a token.
+      matchDatasources: ["docker"],
+      schedule: ["after 4am on monday and tuesday"],
+    },
+    {
+      // Extend the update period because of Docker Hub API rate limits.
+      // That can be avoided by making a self-hosted Renovate and providing a token.
+      matchManagers: ["regex"],
+      schedule: ["after 4am on monday and tuesday"],
+    },
   ],
-  // No files by default. Enable to all possible files                        | https://docs.renovatebot.com/modules/manager/kubernetes/
-  "kubernetes": {
-    "fileMatch": ["\\.yaml$"]
-  },
+  // Limit branch creation to these times of day or week.                     | https://docs.renovatebot.com/configuration-options/#schedule
+  // Deal with docker updates firstly (on Monday) to workaround problems with Docker Rate limits
+  // Other idea - update them in different days at all. IE - docker only tue-wed, other stuff - Monday
+  schedule: ["after 4am on tuesday"],
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve renovate-config!
-->

Put an `x` into the box if that applies:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

Docker API rate limits prevent the creation PRs of any kind of updates, which can block update flow for the whole repo for hours if any docker-related update is available.

To avoid this, we simply update all Docker-specific updates on Monday, and process all other updates (including Docker updates too) on Tuesday.

### How was it tested

During a few months in our infra repo.

How I can see from our huge infra repo with about ~15 docker-related deps, mainly located in the `regex` manager with a few deps from the `docker` manager, that construction works pretty nice