### PR TITLE
fix: Deal with "File contents are invalid JSON but parse using JSON5" issue

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,24 +12,28 @@
     ":semanticCommits",
     ":semanticPrefixFixDepsChoreOthers",
     "regexManagers:dockerfileVersions",
-    "regexManagers:githubActionsVersions"
+    "regexManagers:githubActionsVersions",
   ],
   "dependencyDashboardTitle": "Renovate Dependency Dashboard",
   "dependencyDashboardLabels": ["auto-update"],
   "dependencyDashboardHeader": "This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more.<br>Main configs and useful links are located in [SpotOnInc/renovate-config](https://github.com/SpotOnInc/renovate-config); Renovate logs for debug [here](https://developer.mend.io/{{platform}}/{{repository}}).",
   "minimumReleaseAge": "3 days",
   "rollbackPrs": true,
-  "addLabels": ["auto-update"],
+  "addLabels": [
+    "auto-update",
+  ],
   "configMigration": true,
   "prCreation": "not-pending",
   "vulnerabilityAlerts": {
     "description": "Be sure that the Dependency graph and Dependabot alerts are enabled for the repo. Details: https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts",
     "enabled": true,
-    "addLabels": ["security"]
+    "addLabels": ["security"],
   },
   "terraform": {
-    "ignorePaths": ["**/context.tf"],
-    "pinDigests": true
+    "ignorePaths": [
+      "**/context.tf",
+    ],
+    "pinDigests": true,
   },
   "pre-commit": {
     "enabled": true
@@ -51,13 +55,13 @@
       "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+.*))?$"
     },
     {
-      "matchDatasources": ["docker"],
-      "schedule": ["after 4am on monday and tuesday"]
+      matchDatasources: ["docker"],
+      schedule: ["after 4am on monday and tuesday"],
     },
     {
-      "matchManagers": ["regex"],
-      "schedule": ["after 4am on monday and tuesday"]
-    }
+      matchManagers: ["regex"],
+      schedule: ["after 4am on monday and tuesday"],
+    },
   ],
-  "schedule": ["after 4am on tuesday"]
+  schedule: ["after 4am on tuesday"],
 }

--- a/default.json
+++ b/default.json
@@ -12,28 +12,24 @@
     ":semanticCommits",
     ":semanticPrefixFixDepsChoreOthers",
     "regexManagers:dockerfileVersions",
-    "regexManagers:githubActionsVersions",
+    "regexManagers:githubActionsVersions"
   ],
   "dependencyDashboardTitle": "Renovate Dependency Dashboard",
   "dependencyDashboardLabels": ["auto-update"],
   "dependencyDashboardHeader": "This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more.<br>Main configs and useful links are located in [SpotOnInc/renovate-config](https://github.com/SpotOnInc/renovate-config); Renovate logs for debug [here](https://developer.mend.io/{{platform}}/{{repository}}).",
   "minimumReleaseAge": "3 days",
   "rollbackPrs": true,
-  "addLabels": [
-    "auto-update",
-  ],
+  "addLabels": ["auto-update"],
   "configMigration": true,
   "prCreation": "not-pending",
   "vulnerabilityAlerts": {
     "description": "Be sure that the Dependency graph and Dependabot alerts are enabled for the repo. Details: https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts",
     "enabled": true,
-    "addLabels": ["security"],
+    "addLabels": ["security"]
   },
   "terraform": {
-    "ignorePaths": [
-      "**/context.tf",
-    ],
-    "pinDigests": true,
+    "ignorePaths": ["**/context.tf"],
+    "pinDigests": true
   },
   "pre-commit": {
     "enabled": true
@@ -55,13 +51,13 @@
       "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+.*))?$"
     },
     {
-      matchDatasources: ["docker"],
-      schedule: ["after 4am on monday and tuesday"],
+      "matchDatasources": ["docker"],
+      "schedule": ["after 4am on monday and tuesday"]
     },
     {
-      matchManagers: ["regex"],
-      schedule: ["after 4am on monday and tuesday"],
-    },
+      "matchManagers": ["regex"],
+      "schedule": ["after 4am on monday and tuesday"]
+    }
   ],
-  schedule: ["after 4am on tuesday"],
+  "schedule": ["after 4am on tuesday"]
 }

--- a/default.template.json5
+++ b/default.template.json5
@@ -25,7 +25,7 @@
     // Update `_VERSION` variables in Dockerfiles.                            | https://docs.renovatebot.com/presets-regexManagers/#regexmanagersdockerfileversions
     "regexManagers:dockerfileVersions",
     // Update `_VERSION` environment variables in GitHub Action files.        | https://docs.renovatebot.com/presets-regexManagers/#regexmanagersgithubactionsversions
-    "regexManagers:githubActionsVersions",
+    "regexManagers:githubActionsVersions"
   ],
 
   // Dependency Dashboard issue customization.                                | https://docs.renovatebot.com/configuration-options/#dependencydashboard
@@ -38,9 +38,7 @@
   // if the current version is not found in the registry.                     | https://docs.renovatebot.com/configuration-options/#rollbackprs
   "rollbackPrs": true,
   // All matched addLabels strings will be attached to the PR.                | https://docs.renovatebot.com/configuration-options/#addlabels
-  "addLabels": [
-    "auto-update",
-  ],
+  "addLabels": ["auto-update"],
   // Sometimes you need to change your Renovate configuration.
   // To help with this, Renovate will create config migration pull requests.  | https://docs.renovatebot.com/configuration-options/#configmigration
   "configMigration": true,
@@ -52,14 +50,12 @@
     "description": "Be sure that the Dependency graph and Dependabot alerts are enabled for the repo. Details: https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts",
     "enabled": true,
     // Append `security` label.
-    "addLabels": ["security"],
+    "addLabels": ["security"]
   },
   // Terraform manager custom settings                                        | https://docs.renovatebot.com/modules/manager/terraform/
   "terraform": {
-    "ignorePaths": [
-      "**/context.tf", // Cloud Posse managed
-    ],
-    "pinDigests": true, // Make versions idempotent
+    "ignorePaths": ["**/context.tf"], // Cloud Posse managed
+    "pinDigests": true // Make versions idempotent
   },
   // In beta. Need opt-in. Details - https://docs.renovatebot.com/modules/manager/pre-commit/
   "pre-commit": {
@@ -85,18 +81,18 @@
     {
       // Extend the update period because of Docker Hub API rate limits.
       // That can be avoided by making a self-hosted Renovate and providing a token.
-      matchDatasources: ["docker"],
-      schedule: ["after 4am on monday and tuesday"],
+      "matchDatasources": ["docker"],
+      "schedule": ["after 4am on monday and tuesday"]
     },
     {
       // Extend the update period because of Docker Hub API rate limits.
       // That can be avoided by making a self-hosted Renovate and providing a token.
-      matchManagers: ["regex"],
-      schedule: ["after 4am on monday and tuesday"],
-    },
+      "matchManagers": ["regex"],
+      "schedule": ["after 4am on monday and tuesday"]
+    }
   ],
   // Limit branch creation to these times of day or week.                     | https://docs.renovatebot.com/configuration-options/#schedule
   // Deal with docker updates firstly (on Monday) to workaround problems with Docker Rate limits
   // Other idea - update them in different days at all. IE - docker only tue-wed, other stuff - Monday
-  schedule: ["after 4am on tuesday"],
+  "schedule": ["after 4am on tuesday"]
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve renovate-config!
-->

Put an `x` into the box if that applies:

- [ ] This PR introduces breaking change.
- [X] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Should fix Renovate warning:
> WARN: File contents are invalid JSON but parse using JSON5. Support for this will be removed in a future release so please change to a support .json5 file name or ensure correct JSON syntax.

There might be a deeper issue with how `default.json` is autogenerated in https://github.com/SpotOnInc/renovate-config/blob/main/.github/workflows/generate-renovate-config.yaml#L22-L28 but this should be good enough for now.


<!-- Fixes # -->
<!-- Ticket: -->

### How was it tested

<!--
Before reviewers can be confident in the correctness of this pull request,
it needs to be tested and shown to be correct. Briefly describe the testing
that has already been done or which is planned for this change.
-->



<!--
Last minute questions to consider, please make sure to note the below:

- Does this change require an update to any other applications or third-party libraries?
- Is this change blocked by anything else?
- Does this change require actions outside this PR? For example, updating secrets or keys?
-->
