### PR TITLE
fix: Use `helpers:pinGitHubActionDigestsToSemver`, which implement …

### DIFF
--- a/default.template.json5
+++ b/default.template.json5
@@ -5,8 +5,8 @@
     "config:base",
     // Group various lint packages together.                                  | https://docs.renovatebot.com/presets-group/#grouplinters
     "group:linters",
-    // Pin GitHub Action digests.                                             | https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests
-    "helpers:pinGitHubActionDigests",
+    // Pin GitHub Action digests and pin them to SemVer.                      | https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver
+    "helpers:pinGitHubActionDigestsToSemver",
     // Upgrade Minor and Major Docker tags to newer versions.                 | https://docs.renovatebot.com/presets-preview/#previewdockerversions
     "preview:dockerVersions",
     // Pin Docker digests.                                                    | https://docs.renovatebot.com/presets-docker/#dockerpindigests
@@ -66,12 +66,6 @@
     "fileMatch": ["\\.yaml$"]
   },
   "packageRules": [
-    {
-      "description": "v prefix workaround for action updates",
-      "matchDepTypes": ["action"],
-      "extractVersion": "^(?<version>v\\d+\\.\\d+\\.\\d+)$",
-      "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
-    },
     {
       "description": "Remove v prefix in regex `_VERSION` updates",
       "matchManagers": ["regex"],


### PR DESCRIPTION
…previously used workaround

<!--
Thank you for helping to improve renovate-config!
-->

Put an `x` into the box if that applies:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [x] This PR enhances existing functionality.

### Description of your changes

Replace the custom solution with a new helper which does the same.

### How was it tested

By folks in https://github.com/renovatebot/renovate/discussions/21901#discussioncomment-8379441

> [!IMPORTANT]
> There probability that this replacement or not work well, or bug existed previously, as I saw such issues earlier.
> Check https://github.com/renovatebot/renovate/discussions/27194
>
> @SpotOnInc/open-source please let me know what you think about that - mark PR as draft till Discussion resolution, merge it now or some third way?

