### PR TITLE
feat(security): Track vulnerability alerts from `osv.dev`; Enable OpenSSF badge on PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Otherwise:
 
     ```yaml
     - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v3.0.0-alpha.4
+      rev: v3.1.0
       hooks:
       - id: prettier
         # https://prettier.io/docs/en/options.html#parser

--- a/default.template.json5
+++ b/default.template.json5
@@ -25,7 +25,9 @@
     // Update `_VERSION` variables in Dockerfiles.                            | https://docs.renovatebot.com/presets-regexManagers/#regexmanagersdockerfileversions
     "regexManagers:dockerfileVersions",
     // Update `_VERSION` environment variables in GitHub Action files.        | https://docs.renovatebot.com/presets-regexManagers/#regexmanagersgithubactionsversions
-    "regexManagers:githubActionsVersions"
+    "regexManagers:githubActionsVersions",
+    // Show OpenSSF badge on pull requests.                                   | https://docs.renovatebot.com/presets-security/#securityopenssf-scorecard
+    "security:openssf-scorecard"
   ],
 
   // Dependency Dashboard issue customization.                                | https://docs.renovatebot.com/configuration-options/#dependencydashboard
@@ -52,6 +54,8 @@
     // Append `security` label.
     "addLabels": ["security"]
   },
+  // Use vulnerability alerts from https://osv.dev                            | https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts
+  "osvVulnerabilityAlerts": true,
   // Terraform manager custom settings                                        | https://docs.renovatebot.com/modules/manager/terraform/
   "terraform": {
     "ignorePaths": ["**/context.tf"], // Cloud Posse managed


### PR DESCRIPTION
<!--
Thank you for helping to improve renovate-config!
-->

Put an `x` into the box if that applies:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [x] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Enable some extra security features that will:
* Provide more confidence for developers during PR reviews by showing OpenSSF bagde:
	![image](https://github.com/user-attachments/assets/11fb281c-3c9f-4376-b3cf-215d75bbc851)
* Notify about vulnerabilities based not only on GH Dependabot vulnerabilities DB, but also on community curated OSS Vuln DB - https://osv.dev/



