### PR TITLE
feat(config): Make up-to-date configs and links. Require Renovate v37.357.0+

### DIFF
--- a/default.template.json5
+++ b/default.template.json5
@@ -1,8 +1,8 @@
 {
   "extends": [
     // Default base configuration for all languages.
-    // https://docs.renovatebot.com/presets-config/#configbase
-    "config:base",
+    // https://docs.renovatebot.com/presets-config/#configrecommended
+    "config:recommended",
     // Group various lint packages together.                                  | https://docs.renovatebot.com/presets-group/#grouplinters
     "group:linters",
     // Pin GitHub Action digests.                                             | https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests
@@ -22,10 +22,10 @@
     // If Renovate detects semantic commits, it will use semantic
     // commit type `fix` for dependencies and `chore` for all others.         | https://docs.renovatebot.com/presets-default/#semanticprefixfixdepschoreothers
     ":semanticPrefixFixDepsChoreOthers",
-    // Update `_VERSION` variables in Dockerfiles.                            | https://docs.renovatebot.com/presets-regexManagers/#regexmanagersdockerfileversions
-    "regexManagers:dockerfileVersions",
-    // Update `_VERSION` environment variables in GitHub Action files.        | https://docs.renovatebot.com/presets-regexManagers/#regexmanagersgithubactionsversions
-    "regexManagers:githubActionsVersions"
+    // Update `_VERSION` variables in Dockerfiles.                            | https://docs.renovatebot.com/presets-customManagers/#custommanagersdockerfileversions
+    "customManagers:dockerfileVersions",
+    // Update `_VERSION` environment variables in GitHub Action files.        | https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions
+    "customManagers:githubActionsVersions"
   ],
 
   // Dependency Dashboard issue customization.                                | https://docs.renovatebot.com/configuration-options/#dependencydashboard
@@ -74,7 +74,7 @@
     },
     {
       "description": "Remove v prefix in regex `_VERSION` updates",
-      "matchManagers": ["regex"],
+      "matchManagers": ["custom.regex"],
       "extractVersion": "^?v?(?<version>\\d+\\.\\d+\\.\\d+.*)$",
       "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+.*))?$"
     },
@@ -87,7 +87,7 @@
     {
       // Extend the update period because of Docker Hub API rate limits.
       // That can be avoided by making a self-hosted Renovate and providing a token.
-      "matchManagers": ["regex"],
+      "matchManagers": ["custom.regex"],
       "schedule": ["after 4am on monday and tuesday"]
     }
   ],


### PR DESCRIPTION
BREAKING CHANGE: These changes require Renovate v37.357.0+

<!--
Thank you for helping to improve renovate-config!
-->

Put an `x` into the box if that applies:

- [x] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes


Actually `config:base` renamed to `config:recommended` in v36 https://github.com/renovatebot/renovate/blob/9b64288861fcebfcce7a4938307dec52c04ec54f/docs/usage/release-notes-for-major-versions.md?plain=1#L120

And `regexManagers:` renamed to `customManagers:` in v37.357.0
- https://github.com/renovatebot/renovate/pull/28979

### How was it tested

By creating separate repo with identical to `default.template.json5`  `renovate.json5` file to make sure that there no `migrate renovate config` PR pop-up
