### PR TITLE
fix: Disable `copier` as not working very well

### DIFF
--- a/default.template.json5
+++ b/default.template.json5
@@ -69,6 +69,11 @@
   "kubernetes": {
     "fileMatch": ["\\.yaml$"]
   },
+  // Disable copier until Renovate will support our custom copier structure OR
+  // until Delivery team will change how we use copier
+  "copier": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "description": "v prefix workaround for action updates",


### PR DESCRIPTION
### Description of your changes
Ticket: DEV-8665

Current "copier update" PRs looks this way:

![image](https://github.com/user-attachments/assets/1af344d5-6356-429a-8aeb-cc4f53f75ac3)

Renovate support basic copier usage, but we have our own setup which currently not supported by Renovate, and it's not our priority to fix it right now. So we disable copier for now to avoid useless PRs.


### How was it tested

In another repo which have copier templates - PR was autoclosed after merge of same settings.