### PR TITLE
feat!: Make up-to-date configs. Require Renovate v40.2.0+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         files: 'renovate.json5$'
 
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 39.35.0
+    rev: 42.66.11
     hooks:
       - id: renovate-config-validator
         files: default.template.json5

--- a/default.template.json5
+++ b/default.template.json5
@@ -67,7 +67,7 @@
   },
   // No files by default. Enable to all possible files                        | https://docs.renovatebot.com/modules/manager/kubernetes/
   "kubernetes": {
-    "fileMatch": ["\\.yaml$"]
+    "managerFilePatterns": ["/\\.yaml$/"]
   },
   // Disable copier until Renovate will support our custom copier structure OR
   // until Delivery team will change how we use copier


### PR DESCRIPTION


Put an `x` into the box if that applies:

- [x] This PR introduces breaking change.

### Description of your changes

Migrate `fileMatch` to `filePatterns` - https://github.com/renovatebot/renovate/pull/34615 (v40.2.0+)

Could partially reverted back after merge of https://github.com/renovatebot/renovate/pull/40074

### How was it tested

By creating separate repo where `default.json` used as `renovate-config.json` so it can be validated by Renovate App